### PR TITLE
feat: Process all packages whose current version is unpublished

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
             cargo install cargo-release
           fi
           # '--verbose' was moved to the condition as if yes is '' in 'condition && yes || no' then no is picked (as condition && '' is false)
-          cargo release --no-confirm --workspace ${{ inputs.release_dry_run && '--verbose' || '--verbose --execute' }}
+          cargo release --no-confirm --workspace --unpublished ${{ inputs.release_dry_run && '--verbose' || '--verbose --execute' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
Add flag --unpublished to process all packages whose current version is unpublished. 

The release job is failing because package did-peer already published- https://github.com/affinidi/affinidi-did-resolver/actions/runs/12921629737/job/36216853640#step:7:304.