### PR TITLE
fix: removing explicit wiz-scan in workflows

### DIFF
--- a/.github/workflows/checks-no-test.yaml
+++ b/.github/workflows/checks-no-test.yaml
@@ -66,10 +66,6 @@ jobs:
       rustflags: ${{ inputs.rustflags }}
       ubuntu-rust-deps: ${{ inputs.ubuntu-rust-deps }}
 
-  wiz-scan:
-    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
-    secrets: inherit
-
   rust-scan:
     uses: affinidi/pipeline-security/.github/workflows/rust-scanner.yml@main
     with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -82,10 +82,6 @@ jobs:
       rustflags: ${{ inputs.rustflags }}
       ubuntu-rust-deps: ${{ inputs.ubuntu-rust-deps }}
 
-  wiz-scan:
-    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
-    secrets: inherit
-
   rust-scan:
     uses: affinidi/pipeline-security/.github/workflows/rust-scanner.yml@main
     with:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @affinidi/platform
+* @affinidi/platformers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @platform
+* @affinidi/platform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @maratsh @iharvarauka @robert-affinidi @raja-sekhar-r 
+* @platform

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @affinidi/platformers
+* @affinidi/platform


### PR DESCRIPTION
This PR
- Removed explicitly calling wiz-scan as this is taken care of by rust-scanner
- Updated codeowners