### PR TITLE
fix: skip crates with publish = false in verify-publish

### DIFF
--- a/.github/workflows/verify-publish.yaml
+++ b/.github/workflows/verify-publish.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "Verifying all workspace crates can be packaged..."
           failed=""
-          for crate in $(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].name'); do
+          for crate in $(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.publish == null) | .name'); do
             echo -n "Checking $crate... "
             # Suppress deprecation warnings during package check
             if output=$(RUSTFLAGS="${{ inputs.rustflags }} -A deprecated" cargo package -p "$crate" --allow-dirty 2>&1); then


### PR DESCRIPTION
## Summary
- The verify-publish workflow now skips crates that have `publish = false` in their Cargo.toml
- In cargo metadata, these crates have `"publish": []` vs `null` for publishable crates
- This prevents false failures when workspace crates intentionally opt out of publishing (e.g., binary-only helper crates)

## Test plan
- [ ] Verify that publishable crates are still checked
- [ ] Verify that `publish = false` crates are skipped