### PR TITLE
release: skip already-published crates in workspace_publish path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,9 +114,66 @@ jobs:
       #     CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       # --- workspace publish path (cargo publish --workspace) ---
-      - name: Publish workspace
+      # `cargo publish --workspace` errors on the first crate whose current
+      # version is already on crates.io instead of skipping it, which blocks
+      # targeted patch releases that only bump a subset of workspace members.
+      # This step compares the local manifest version against the registry
+      # for every publishable crate, builds an `--exclude` list for matches,
+      # and signals when nothing is left to publish.
+      - name: Plan workspace publish (skip already-published crates)
+        id: workspace-publish-plan
         if: ${{ github.ref == 'refs/heads/main' && inputs.workspace_publish }}
-        run: cargo publish --workspace ${{ inputs.release_dry_run && '--dry-run' || '' }}
+        run: |
+          set -euo pipefail
+          debug="${{ inputs.release_debug }}"
+          exclude_args=""
+          skipped=()
+          publishable=()
+
+          while IFS=$'\t' read -r name version; do
+              remote_version=""
+              if info_output=$(cargo info --registry crates-io --color never "${name}" 2>/dev/null); then
+                  remote_version=$(printf '%s\n' "${info_output}" | awk '/^version:/ { print $2; exit }')
+              fi
+
+              if [[ "${debug}" == "true" ]]
+              then
+                  echo "  ${name}: local=${version} remote=${remote_version:-<not published>}"
+              fi
+
+              if [[ -n "${remote_version}" && "${remote_version}" == "${version}" ]]
+              then
+                  exclude_args+=" --exclude ${name}"
+                  skipped+=("${name}@${version}")
+              else
+                  publishable+=("${name}@${version}")
+              fi
+          done < <(cargo metadata --no-deps --format-version 1 \
+              | jq -r '.packages[] | select(.publish != []) | [.name, .version] | @tsv')
+
+          echo ""
+          echo "=== Workspace publish plan ==="
+          if [[ ${#publishable[@]} -gt 0 ]]
+          then
+              echo "Will publish (${#publishable[@]}):"
+              printf '  - %s\n' "${publishable[@]}"
+          else
+              echo "Nothing to publish — every publishable workspace crate is already at its registry version."
+          fi
+          if [[ ${#skipped[@]} -gt 0 ]]
+          then
+              echo "Already on crates.io, skipping (${#skipped[@]}):"
+              printf '  - %s\n' "${skipped[@]}"
+          fi
+
+          {
+              echo "exclude_args=${exclude_args}"
+              echo "publishable_count=${#publishable[@]}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Publish workspace
+        if: ${{ github.ref == 'refs/heads/main' && inputs.workspace_publish && steps.workspace-publish-plan.outputs.publishable_count != '0' }}
+        run: cargo publish --workspace${{ steps.workspace-publish-plan.outputs.exclude_args }}${{ inputs.release_dry_run && ' --dry-run' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Why

`cargo publish --workspace` — what the `workspace_publish: true` path invokes — has no built-in "skip already-published" behaviour. It errors on the first crate whose current version is already on crates.io:

```
error: crate affinidi-cesr@0.1.0 already exists on crates.io index
```

That is the wrong shape for workspaces that ship targeted patch releases. Since PR #71 merged and consumers enabled `workspace_publish: true`, the first release in [affinidi-tdk-rs](https://github.com/affinidi/affinidi-tdk-rs) that only bumped a subset of crates (four of ~40, for a security fix) failed immediately on an untouched member.

Failing consumer run:
https://github.com/affinidi/affinidi-tdk-rs/actions/runs/24549726755/job/71772932292

The legacy per-crate path already does the right thing — it compares `local_version` vs. `remote_version` and only publishes when they differ. This PR brings the same behaviour to the workspace path without giving up the benefits of `cargo publish --workspace` (dependency ordering, single transaction, trusted-publishing token scope).

## What

A new "Plan workspace publish" step runs before `Publish workspace`:

1. Walk publishable members from `cargo metadata` (`select(.publish != [])`).
2. For each, ask `cargo info --registry crates-io` for the latest published version. If the registry version equals the local manifest version, record the crate as skipped and add `--exclude <name>` to the accumulator.
3. Print a plan summary — which crates will be published and which will be skipped — so release logs make the intent obvious. Extra per-crate debug output under `release_debug: true`.
4. Pass the accumulated `--exclude` args to `cargo publish --workspace`. Skip the publish step entirely when nothing is left to publish (all members already at their registry version).

Tagging, auth, and the legacy per-crate path are unchanged. The existing tag step already handles pre-existing tags via `git rev-parse`, so it stays consistent with a narrower publish set.

## Manual verification

Simulated with mocked `cargo metadata` + `cargo info` covering the interesting cases:

```
  crate-a: local=0.1.2 remote=0.1.1          # bumped -> publish
  crate-b: local=0.2.0 remote=0.2.0          # match  -> skip
  crate-d: local=1.0.1 remote=<not published> # new    -> publish

=== Workspace publish plan ===
Will publish (2):
  - crate-a@0.1.2
  - crate-d@1.0.1
Already on crates.io, skipping (1):
  - crate-b@0.2.0
exclude_args= --exclude crate-b
publishable_count=2
```

(And `crate-c` with `publish = false` is filtered out at the metadata step, matching the behaviour of the existing tag step.)

YAML parses cleanly and the embedded shell passes `bash -n`.

## Checklist

- [x] DCO sign-off
- [x] Legacy per-crate path untouched
- [x] Tagging step still works (it already no-ops on pre-existing tags)
- [x] Respects `release_dry_run` and `release_debug`