### PR TITLE
fix: get name from metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,7 +239,7 @@ jobs:
 
                   echo "Publishing crate $crate..."
 
-                  crate_name=${crate##*/}
+                  crate_name=$(cargo metadata --no-deps --format-version 1 --manifest-path "${crate}/Cargo.toml" | jq -r '.packages[0].name')
                   if [[ "${debug}" == "true" ]]
                   then
                       echo "crate_name=${crate_name}"


### PR DESCRIPTION
Fix for the edge case when crate name diverges from repo name - make Cargo.toml the single source of truth