### PR TITLE
fix: release — workspace-aware crate name extraction

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -239,7 +239,19 @@ jobs:
 
                   echo "Publishing crate $crate..."
 
-                  crate_name=$(cargo metadata --no-deps --format-version 1 --manifest-path "${crate}/Cargo.toml" | jq -r '.packages[0].name')
+                  # Use `cargo read-manifest` to read [package].name from the
+                  # specified Cargo.toml only. `cargo metadata --no-deps
+                  # --manifest-path X` expands to ALL workspace members when X
+                  # belongs to a workspace, so `.packages[0].name` always
+                  # returned the first declared workspace member regardless of
+                  # which crate we were processing — every iteration treated
+                  # the loop body as if it were the first crate, comparing
+                  # that crate's local vs remote and skipping the publish for
+                  # everything else. `read-manifest` reads the single TOML
+                  # without workspace expansion, while still honouring PR #74's
+                  # original intent that [package].name (not the directory
+                  # name) is the source of truth.
+                  crate_name=$(cargo read-manifest --manifest-path "${crate}/Cargo.toml" | jq -r '.name')
                   if [[ "${debug}" == "true" ]]
                   then
                       echo "crate_name=${crate_name}"


### PR DESCRIPTION
## Summary

PR #74 changed the legacy per-crate publish loop's crate-name extraction from the directory basename to a `cargo metadata`-based lookup, with the correct intent of making `[package].name` the source of truth. The implementation breaks in workspaces.

```yaml
# Current (broken in workspaces):
crate_name=\$(cargo metadata --no-deps --format-version 1 \
    --manifest-path \"\${crate}/Cargo.toml\" | jq -r '.packages[0].name')
```

`cargo metadata --no-deps --manifest-path <member>/Cargo.toml` returns **all** workspace members when the manifest belongs to a workspace, not just the targeted crate. `.packages[0].name` therefore always returns the first workspace member declared in `[workspace.members]` — regardless of which crate the loop is processing.

### Concrete failure observed

In `affinidi/affinidi-tdk-rs` (workspace where `affinidi-cesr` is the first declared member), every iteration of the publish loop logged:

```
Publishing crate /home/runner/.../affinidi-messaging-sdk...
crate_name=affinidi-cesr
local_version=0.1.1
remote_version=0.1.1
No release needed for affinidi-cesr as version [0.1.1] was already released.
```

Result: **zero crates published, zero git tags pushed, run reports green**. Run 25589907393 (merge of `affinidi-tdk-rs#310`, an SDK + didcomm-service patch) was supposed to publish `affinidi-messaging-sdk@0.18.2` and `affinidi-messaging-didcomm-service@0.3.1`. Neither hit crates.io. The previous main run (25422250500, mediator 0.15.2) had the same broken behaviour — mediator 0.15.2 is on crates.io only because an earlier run from before the regression had already published it.

## Fix

Switch to `cargo read-manifest --manifest-path X | jq -r .name`. `read-manifest` reads only the specified Cargo.toml's `[package]` block without expanding into workspace members, while still honouring PR #74's intent that `[package].name` (not the directory basename) is the source of truth.

Verified locally:

| Scenario | Old behaviour | New behaviour |
|---|---|---|
| Workspace member at `crates/messaging/affinidi-messaging-sdk/Cargo.toml` | Returns `affinidi-cesr` (wrong) | Returns `affinidi-messaging-sdk` |
| Single-crate repo where `[package].name` differs from directory name | Returns correct name (worked, since not a workspace) | Returns correct name |
| Single-crate repo where `[package].name` matches directory name | Returns correct name | Returns correct name |

PR #74's edge case (name diverges from directory) is preserved. The regression in workspaces is fixed.

## Test plan

- [x] Reproduced the bug locally against `affinidi-tdk-rs` workspace: `cargo metadata --no-deps --format-version 1 --manifest-path crates/messaging/affinidi-messaging-sdk/Cargo.toml | jq -r '.packages[0].name'` → `affinidi-cesr` (wrong)
- [x] Verified the fix locally: `cargo read-manifest --manifest-path crates/messaging/affinidi-messaging-sdk/Cargo.toml | jq -r .name` → `affinidi-messaging-sdk` (correct)
- [x] Verified the fix preserves PR #74's intent on a single-crate repo with `[package].name = \"actual-package-name\"` in a directory called `test-cargo`: returns `actual-package-name`
- [ ] CI green on this PR (pipeline-rust's own checks)
- [ ] Once merged: re-run `affinidi-tdk-rs` release.yaml on `main` and confirm `affinidi-messaging-sdk@0.18.2` and `affinidi-messaging-didcomm-service@0.3.1` upload to crates.io and corresponding git tags appear