### PR TITLE
fix(release): per-crate isolated, version-gated publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,8 +94,12 @@ jobs:
         with:
           ubuntu-rust-deps: ${{ inputs.ubuntu-rust-deps }}
 
-      - name: Build project
-        run: cargo build --release
+      # NOTE: no unconditional `cargo build --release` here. A full-workspace
+      # build at release time is slow and couples every crate's fate together
+      # (one unrelated broken crate fails the whole release before anything
+      # publishes). Full-workspace compile/verify is gated on PRs by the checks
+      # workflow (verifyPublish: true); at release time each crate is verified
+      # in isolation by its own `cargo publish -p` below.
 
       - name: Authenticate to crates.io (OIDC trusted publishing)
         id: auth
@@ -122,7 +126,7 @@ jobs:
       # and signals when nothing is left to publish.
       - name: Plan workspace publish (skip already-published crates)
         id: workspace-publish-plan
-        if: ${{ github.ref == 'refs/heads/main' && inputs.workspace_publish }}
+        if: ${{ (github.ref == 'refs/heads/main' || inputs.release_dry_run) && inputs.workspace_publish }}
         run: |
           set -euo pipefail
           debug="${{ inputs.release_debug }}"
@@ -172,8 +176,9 @@ jobs:
           } >> "${GITHUB_OUTPUT}"
 
       - name: Publish workspace
-        if: ${{ github.ref == 'refs/heads/main' && inputs.workspace_publish && steps.workspace-publish-plan.outputs.publishable_count != '0' }}
-        run: cargo publish --workspace${{ steps.workspace-publish-plan.outputs.exclude_args }}${{ inputs.release_dry_run && ' --dry-run' || '' }}
+        if: ${{ (github.ref == 'refs/heads/main' || inputs.release_dry_run) && inputs.workspace_publish && steps.workspace-publish-plan.outputs.publishable_count != '0' }}
+        # Branches always dry-run: only a real push to main publishes for real.
+        run: cargo publish --workspace${{ steps.workspace-publish-plan.outputs.exclude_args }}${{ (inputs.release_dry_run || github.ref != 'refs/heads/main') && ' --dry-run' || '' }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -191,126 +196,121 @@ jobs:
             fi
           done
 
-      # --- legacy per-crate publish path (pre-1.90 or no workspace inheritance) ---
-      - name: Release (legacy)
-        if: ${{ github.ref == 'refs/heads/main' && !inputs.workspace_publish }}
-        run: |
-          debug="${{ inputs.release_debug }}"
-          max_retries=${{ inputs.release_max_retries }}
-          retries=0
-          all_published_crates=()
-          published_crates=()
-          failed_crates=()
-
-          while [[ ${#published_crates[@]} -gt 0 || ${#failed_crates[@]} -gt 0 || $retries == 0 ]]
-          do
-              if [[ $retries == $max_retries ]]
-              then
-                  echo "Max retries (${max_retries}) reached, exiting."
-                  if [[ ${#failed_crates[@]} -gt 0 ]]
-                  then
-                      echo "Creates published in the current run: [${all_published_crates[@]}]."
-                      echo "Crates which were not published: [${failed_crates[@]}]."
-                  fi
-                  exit 1
-              elif [[ $retries -gt 0 ]]
-              then
-                  if [[ ${#failed_crates[@]} -eq 0 ]]
-                  then
-                      echo "Seems all crates were published."
-                      break
-                  fi
-              fi
-              retries=$((retries + 1))
-              if [[ $retries -gt 1 ]]
-              then
-                  echo "[${retries}/${max_retries}] Creates published in the previous run: [${published_crates[@]}]"
-                  echo "[${retries}/${max_retries}] Creates failed in the previous run: [${failed_crates[@]}]"
-              fi
-              published_crates=()
-              failed_crates=()
-              for crate in $(cargo metadata --format-version=1 --no-deps | jq -r '.packages[].manifest_path' | xargs dirname)
-              do
-                  if grep -q "publish = false" "${crate}/Cargo.toml"
-                  then
-                    echo "Skipping $crate..."
-                    continue
-                  fi
-
-                  echo "Publishing crate $crate..."
-
-                  # Use `cargo read-manifest` to read [package].name from the
-                  # specified Cargo.toml only. `cargo metadata --no-deps
-                  # --manifest-path X` expands to ALL workspace members when X
-                  # belongs to a workspace, so `.packages[0].name` always
-                  # returned the first declared workspace member regardless of
-                  # which crate we were processing — every iteration treated
-                  # the loop body as if it were the first crate, comparing
-                  # that crate's local vs remote and skipping the publish for
-                  # everything else. `read-manifest` reads the single TOML
-                  # without workspace expansion, while still honouring PR #74's
-                  # original intent that [package].name (not the directory
-                  # name) is the source of truth.
-                  crate_name=$(cargo read-manifest --manifest-path "${crate}/Cargo.toml" | jq -r '.name')
-                  if [[ "${debug}" == "true" ]]
-                  then
-                      echo "crate_name=${crate_name}"
-                  fi
-
-                  if [[ "${debug}" == "true" ]]
-                  then
-                      cargo info ${crate_name} | grep "version" | grep --invert-match "rust-version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "Cannot fetch remote version"
-                  fi
-                  local_version=$(cargo info ${crate_name} | grep "version" | grep --invert-match "rust-version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-                  if [[ "${debug}" == "true" ]]
-                  then
-                      echo local_version=${local_version}
-                  fi
-
-                  if [[ "${debug}" == "true" ]]
-                  then
-                      cargo search --limit 1 --quiet ${crate_name} | grep --before-context=0 --after-context=0 ${crate_name} | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "Cannot fetch remote version"
-                  fi
-                  remote_version=$(cargo search --limit 1 --quiet ${crate_name} | grep --before-context=0 --after-context=0 ${crate_name} | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "")
-                  if [[ "${debug}" == "true" ]]
-                  then
-                      echo remote_version=${remote_version}
-                  fi
-
-                  if [[ "${local_version}" != "${remote_version}" ]]
-                  then
-                      cd $crate
-                      echo "Publishing ${crate_name}@${local_version}]..."
-                      set +e
-                      cargo publish ${{ inputs.release_dry_run && '--dry-run' || '' }}
-                      publish_exit_code=$?
-                      set -e
-                      if [[ "$publish_exit_code" == "0" ]]
-                      then
-                          if [[ ! ${all_published_crates[@]} =~ $crate_name ]]
-                          then
-                              all_published_crates+=($crate_name)
-                          fi
-                          published_crates+=($crate_name)
-                      else
-                          failed_crates+=($crate_name)
-                      fi
-                      cd ..
-
-                      tag_version="${crate_name}-v${local_version}"
-                      git tag --annotate "${tag_version}" --message="Release tag for ${tag_version}" || echo "Tag [${tag_version}] already exists"
-                  else
-                      echo "No release needed for ${crate_name} as version [${remote_version}] was already released."
-                  fi
-              done
-          done
-          echo "Creates published in the current run: [${all_published_crates[@]}]."
-          echo "Creates failed in the current run: [${failed_crates[@]}]."
+      # --- per-crate publish path (isolated, version-gated) ---
+      # Publishes each publishable workspace crate independently, only when its
+      # local version is STRICTLY GREATER than what is on crates.io. Key
+      # properties:
+      #   * `cargo publish -p <crate>` verifies only that crate's dependency
+      #     tree, so an unrelated broken crate never blocks the others and the
+      #     whole workspace is not recompiled.
+      #   * Unchanged / equal versions are skipped entirely (no build, no
+      #     publish); downgrades are never attempted.
+      #   * Remote versions come from the crates.io sparse index (fast, no
+      #     downloads, no `cargo search` rate limits).
+      #   * Bounded retries resolve dependency ordering / index propagation; a
+      #     pass that makes no progress stops early and reports real failures.
+      #   * Off `main` (or when release_dry_run) everything runs as `--dry-run`,
+      #     so this is fully exercisable from a PR / test branch.
+      - name: Release (per-crate)
+        if: ${{ (github.ref == 'refs/heads/main' || inputs.release_dry_run) && !inputs.workspace_publish }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token || secrets.CARGO_REGISTRY_TOKEN }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DEBUG: ${{ inputs.release_debug }}
+          MAX_RETRIES: ${{ inputs.release_max_retries }}
+          # Branches never publish for real — only a push to main with
+          # release_dry_run=false does.
+          FORCE_DRY_RUN: ${{ inputs.release_dry_run || github.ref != 'refs/heads/main' }}
+        run: |
+          set -uo pipefail
+          dry=""
+          [ "${FORCE_DRY_RUN}" = "true" ] && dry="--dry-run"
 
+          # Latest non-yanked version on crates.io via the sparse index.
+          published_version() {
+            local n="$1" p
+            case "${#n}" in
+              1) p="1/$n" ;;
+              2) p="2/$n" ;;
+              3) p="3/${n:0:1}/$n" ;;
+              *) p="${n:0:2}/${n:2:2}/$n" ;;
+            esac
+            curl -fsSL "https://index.crates.io/$p" 2>/dev/null \
+              | jq -rs 'map(select(.yanked | not).vers) | sort_by(split(".") | map(tonumber? // 0)) | last // ""'
+          }
+          # True iff $1 is a strictly higher semver than $2.
+          version_gt() { [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]; }
+
+          # Local versions of every publishable workspace crate (one metadata call).
+          declare -A ver
+          while IFS=$'\t' read -r name version; do
+            ver["$name"]="$version"
+          done < <(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.publish != []) | [.name, .version] | @tsv')
+
+          # Version-gate: queue only crates whose local version is strictly newer.
+          todo=()
+          for name in "${!ver[@]}"; do
+            lv="${ver[$name]}"
+            rv="$(published_version "$name")"
+            if [ -n "$rv" ] && ! version_gt "$lv" "$rv"; then
+              echo "skip   $name ($lv <= crates.io $rv)"
+            else
+              echo "queue  $name ($lv; crates.io ${rv:-<new>})"
+              todo+=("$name")
+            fi
+          done
+
+          if [ "${#todo[@]}" -eq 0 ]; then
+            echo "Nothing to publish — every publishable crate is already at its registry version."
+            exit 0
+          fi
+
+          # Publish queued crates in isolation, with bounded retries for
+          # dependency ordering / index propagation. Stop early once a whole
+          # pass makes no progress (remaining failures are real, not ordering).
+          retries=0
+          pending=("${todo[@]}")
+          published=()
+          while [ "${#pending[@]}" -gt 0 ] && [ "$retries" -lt "$MAX_RETRIES" ]; do
+            retries=$((retries + 1))
+            round=("${pending[@]}")
+            pending=()
+            progress=0
+            for name in "${round[@]}"; do
+              echo "::group::[$retries/$MAX_RETRIES] publish $name@${ver[$name]} $dry"
+              if cargo publish -p "$name" $dry; then
+                echo "published $name@${ver[$name]}"
+                published+=("$name@${ver[$name]}")
+                progress=1
+                if [ -z "$dry" ]; then
+                  git tag --annotate "$name-v${ver[$name]}" --message="Release $name v${ver[$name]}" 2>/dev/null \
+                    || echo "tag $name-v${ver[$name]} already exists"
+                fi
+              else
+                echo "::warning::publish failed (will retry if progress is made): $name@${ver[$name]}"
+                pending+=("$name")
+              fi
+              echo "::endgroup::"
+            done
+            if [ "$progress" -eq 0 ]; then
+              break
+            fi
+            [ "${#pending[@]}" -gt 0 ] && sleep 15
+          done
+
+          echo "=== Publish summary ==="
+          echo "Published (${#published[@]}): ${published[*]:-none}"
+          if [ "${#pending[@]}" -gt 0 ]; then
+            echo "::error::failed to publish after ${retries} attempt(s): ${pending[*]}"
+            exit 1
+          fi
+
+      # always(): a partial failure (e.g. one crate blocked on an external dep)
+      # still publishes the others irreversibly, so their tags must be pushed
+      # even though an earlier step exited non-zero.
       - name: Push Tags
+        if: ${{ always() && github.ref == 'refs/heads/main' && !inputs.release_dry_run }}
         run: git push --follow-tags
 
       - name: Check disk usage


### PR DESCRIPTION
## Problem

The reusable `release.yaml` runs an unconditional **full-workspace `cargo build --release`** before any publish logic. This:

- **Is slow** — recompiles every workspace crate + all deps in release mode on every push to `main`, even when nothing needs releasing.
- **Couples all crates together** — if any single crate can't build (e.g. blocked on an external dependency that hasn't been updated yet), the whole release fails *before anything publishes*. This blocked an `affinidi-crypto` release in `affinidi-tdk-rs`: a major bump un-unified an external crate (`vta-sdk`) from the workspace `[patch.crates-io]` redirect, and the upfront build failed on it.
- The legacy per-crate loop also published on `local != remote` (would attempt a downgrade), used `cargo info` + `cargo search` (slow, rate-limited), and leaned on a 10× retry loop for ordering.

## Changes (legacy / `workspace_publish: false` path)

- **Remove the upfront `cargo build --release`.** Full-workspace compile/verify is already gated on PRs by the `checks` workflow (`verifyPublish: true`); at release time each crate is verified in isolation by its own `cargo publish -p`.
- **Per-crate, isolated, version-gated publish:** publish each publishable workspace crate independently, and **only when its local version is strictly greater** than what's on crates.io (skip unchanged/equal; never downgrade). `cargo publish -p <crate>` compiles only that crate's dependency tree, so one broken crate no longer blocks the others; already-published crates are skipped, making re-runs idempotent.
- **Sparse-index version lookup** (`https://index.crates.io/...`) instead of `cargo info`/`cargo search` — fast, no downloads, no rate limits.
- **Bounded retries** resolve dependency ordering / index propagation; a pass with no progress stops early and reports the genuine failures.
- **`always()` on tag push** so a partial failure still pushes tags for crates that did publish.

## Testability

The publish steps now also run (forced `--dry-run`) **off `main`** and when `release_dry_run=true`, so the whole path is exercisable from a PR / test branch without publishing for real. **Branches can never publish for real** — only a push to `main` with `release_dry_run=false` does (`FORCE_DRY_RUN = release_dry_run || github.ref != 'refs/heads/main'`).

## Validation

- Workflow YAML parses; the `run` body passes `bash -n`.
- The version-gate was run against the live `affinidi-tdk-rs` workspace: it queued exactly the 9 crates whose local version exceeds crates.io and skipped all 29 unchanged ones (matching the intended staged release).

## Notes

- The `workspace_publish: true` path is unchanged in behaviour except it no longer depends on the removed global build and is now dry-run-testable off `main`. `cargo publish --workspace` verifies the set atomically, so it does not give the same one-broken-crate isolation — the per-crate path is preferred for staged/partial releases.