### PR TITLE
chore: remove wiz scan from workflows

### DIFF
--- a/.github/workflows/checks-no-test.yaml
+++ b/.github/workflows/checks-no-test.yaml
@@ -66,10 +66,6 @@ jobs:
       rustflags: ${{ inputs.rustflags }}
       ubuntu-rust-deps: ${{ inputs.ubuntu-rust-deps }}
 
-  wiz-scan:
-    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
-    secrets: inherit
-
   rust-scan:
     uses: affinidi/pipeline-security/.github/workflows/rust-scanner.yml@main
     with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -82,10 +82,6 @@ jobs:
       rustflags: ${{ inputs.rustflags }}
       ubuntu-rust-deps: ${{ inputs.ubuntu-rust-deps }}
 
-  wiz-scan:
-    uses: affinidi/pipeline-security/.github/workflows/wizcli-dirscan.yml@main
-    secrets: inherit
-
   rust-scan:
     uses: affinidi/pipeline-security/.github/workflows/rust-scanner.yml@main
     with:


### PR DESCRIPTION
Removes the `wiz-scan` job from `checks.yaml` and `checks-no-test.yaml`.